### PR TITLE
Add configurable signal handling, RunE, ExecuteE, and doc comments

### DIFF
--- a/cobras.go
+++ b/cobras.go
@@ -15,7 +15,36 @@ type Options interface {
 	Run(ctx context.Context) error
 }
 
-func Run(opts Options) func(cmd *cobra.Command, args []string) {
+type RunOption func(*config)
+
+type config struct {
+	signals []os.Signal
+}
+
+func defaultConfig() config {
+	return config{
+		signals: []os.Signal{os.Interrupt},
+	}
+}
+
+func applyOptions(options []RunOption) config {
+	cfg := defaultConfig()
+	for _, o := range options {
+		o(&cfg)
+	}
+	return cfg
+}
+
+// WithSignals overrides which signals cancel the context.
+// Pass no arguments to disable signal handling.
+func WithSignals(signals ...os.Signal) RunOption {
+	return func(c *config) {
+		c.signals = signals
+	}
+}
+
+func Run(opts Options, options ...RunOption) func(cmd *cobra.Command, args []string) {
+	cfg := applyOptions(options)
 	return func(cmd *cobra.Command, args []string) {
 		err := opts.Complete(cmd, args)
 		if err != nil {
@@ -27,22 +56,32 @@ func Run(opts Options) func(cmd *cobra.Command, args []string) {
 			printErrorAndDie(err)
 		}
 
-		err = opts.Run(cmd.Context())
+		ctx := cmd.Context()
+		if len(cfg.signals) > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = signal.NotifyContext(ctx, cfg.signals...)
+			defer cancel()
+		}
+
+		err = opts.Run(ctx)
 		if err != nil {
 			printErrorAndDie(err)
 		}
 	}
 }
 
-func Context() (ctx context.Context, cancel func()) {
-	// trap Ctrl+C and call cancel on the context
+func Context(options ...RunOption) (ctx context.Context, cancel func()) {
+	cfg := applyOptions(options)
 	ctx, origCancel := context.WithCancel(context.Background())
+	if len(cfg.signals) == 0 {
+		return ctx, origCancel
+	}
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, cfg.signals...)
 	go func() {
 		select {
 		case <-c:
-			cancel()
+			origCancel()
 		case <-ctx.Done():
 		}
 	}()
@@ -52,8 +91,8 @@ func Context() (ctx context.Context, cancel func()) {
 	}
 }
 
-func Execute(cmd *cobra.Command) {
-	ctx, cancel := Context()
+func Execute(cmd *cobra.Command, options ...RunOption) {
+	ctx, cancel := Context(options...)
 	defer cancel()
 	err := cmd.ExecuteContext(ctx)
 	if err != nil {

--- a/cobras.go
+++ b/cobras.go
@@ -1,3 +1,5 @@
+// Package cobras provides helpers for building Cobra-based CLIs with
+// signal-aware context management and a structured command lifecycle.
 package cobras
 
 import (
@@ -9,13 +11,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Options defines a three-phase command lifecycle:
+//
+//  1. Complete binds command-line flags and positional arguments to the receiver.
+//  2. Validate checks that the bound values form a valid configuration.
+//  3. Run executes the command logic with a context that is canceled on
+//     the configured OS signals (default: SIGINT).
+//
+// Use [Run] or [RunE] to wire an Options implementation into a [cobra.Command].
 type Options interface {
 	Complete(cmd *cobra.Command, args []string) error
 	Validate() error
 	Run(ctx context.Context) error
 }
 
-type RunOption func(*config)
+// ExecuteOption configures the behavior of [Execute].
+type ExecuteOption func(*config)
 
 type config struct {
 	signals []os.Signal
@@ -23,11 +34,12 @@ type config struct {
 
 func defaultConfig() config {
 	return config{
+		// Defaults to SIGINT for backward compatibility
 		signals: []os.Signal{os.Interrupt},
 	}
 }
 
-func applyOptions(options []RunOption) config {
+func applyOptions(options []ExecuteOption) config {
 	cfg := defaultConfig()
 	for _, o := range options {
 		o(&cfg)
@@ -37,14 +49,19 @@ func applyOptions(options []RunOption) config {
 
 // WithSignals overrides which signals cancel the context.
 // Pass no arguments to disable signal handling.
-func WithSignals(signals ...os.Signal) RunOption {
+func WithSignals(signals ...os.Signal) ExecuteOption {
 	return func(c *config) {
 		c.signals = signals
 	}
 }
 
-func Run(opts Options, options ...RunOption) func(cmd *cobra.Command, args []string) {
-	cfg := applyOptions(options)
+// Run returns a function compatible with [cobra.Command.Run] that drives the
+// Complete→Validate→Run lifecycle on opts. If any phase returns an error the
+// process prints it to stderr and exits with code 1.
+//
+// The command's context (set by [Execute] or [cobra.Command.ExecuteContext]) is
+// passed through to opts.Run.
+func Run(opts Options) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		err := opts.Complete(cmd, args)
 		if err != nil {
@@ -56,20 +73,33 @@ func Run(opts Options, options ...RunOption) func(cmd *cobra.Command, args []str
 			printErrorAndDie(err)
 		}
 
-		ctx := cmd.Context()
-		if len(cfg.signals) > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = signal.NotifyContext(ctx, cfg.signals...)
-			defer cancel()
-		}
-
-		err = opts.Run(ctx)
+		err = opts.Run(cmd.Context())
 		if err != nil {
 			printErrorAndDie(err)
 		}
 	}
 }
 
+// RunE returns a function compatible with [cobra.Command.RunE] that drives the
+// Complete→Validate→Run lifecycle on opts. Unlike [Run], errors are returned
+// to the caller instead of printing and exiting.
+func RunE(opts Options) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := opts.Complete(cmd, args); err != nil {
+			return err
+		}
+		if err := opts.Validate(); err != nil {
+			return err
+		}
+		return opts.Run(cmd.Context())
+	}
+}
+
+// Context creates a background context that is cancelled when one of the given
+// signals is received.
+//
+// If no signals are provided it defaults to SIGINT for backward compatibility.
+// The returned cancel function stops signal listening and cancels the context.
 func Context(signals ...os.Signal) (ctx context.Context, cancel func()) {
 	if len(signals) == 0 {
 		signals = defaultConfig().signals
@@ -90,17 +120,26 @@ func Context(signals ...os.Signal) (ctx context.Context, cancel func()) {
 	}
 }
 
-func Execute(cmd *cobra.Command, options ...RunOption) {
+// ExecuteE is a convenience entrypoint that creates a signal-aware context and
+// calls [cobra.Command.ExecuteContext]. Unlike [Execute], errors are returned
+// to the caller instead of printing and exiting.
+func ExecuteE(cmd *cobra.Command, options ...ExecuteOption) error {
 	cfg := applyOptions(options)
 	ctx, cancel := Context(cfg.signals...)
 	defer cancel()
-	err := cmd.ExecuteContext(ctx)
-	if err != nil {
+	return cmd.ExecuteContext(ctx)
+}
+
+// Execute is a convenience entrypoint that creates a signal-aware context and
+// calls [cobra.Command.ExecuteContext]. If execution fails the process prints
+// the error to stderr and exits with code 1.
+func Execute(cmd *cobra.Command, options ...ExecuteOption) {
+	if err := ExecuteE(cmd, options...); err != nil {
 		printErrorAndDie(err)
 	}
 }
 
 func printErrorAndDie(err error) {
-	fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 	os.Exit(1)
 }

--- a/cobras.go
+++ b/cobras.go
@@ -70,14 +70,13 @@ func Run(opts Options, options ...RunOption) func(cmd *cobra.Command, args []str
 	}
 }
 
-func Context(options ...RunOption) (ctx context.Context, cancel func()) {
-	cfg := applyOptions(options)
-	ctx, origCancel := context.WithCancel(context.Background())
-	if len(cfg.signals) == 0 {
-		return ctx, origCancel
+func Context(signals ...os.Signal) (ctx context.Context, cancel func()) {
+	if len(signals) == 0 {
+		signals = defaultConfig().signals
 	}
+	ctx, origCancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, cfg.signals...)
+	signal.Notify(c, signals...)
 	go func() {
 		select {
 		case <-c:
@@ -92,7 +91,8 @@ func Context(options ...RunOption) (ctx context.Context, cancel func()) {
 }
 
 func Execute(cmd *cobra.Command, options ...RunOption) {
-	ctx, cancel := Context(options...)
+	cfg := applyOptions(options)
+	ctx, cancel := Context(cfg.signals...)
 	defer cancel()
 	err := cmd.ExecuteContext(ctx)
 	if err != nil {

--- a/cobras_test.go
+++ b/cobras_test.go
@@ -1,7 +1,6 @@
 package cobras
 
 import (
-	"context"
 	"os"
 	"syscall"
 	"testing"
@@ -52,7 +51,7 @@ func TestContextDefaultCancelsOnInterrupt(t *testing.T) {
 }
 
 func TestContextWithCustomSignal(t *testing.T) {
-	ctx, cancel := Context(WithSignals(syscall.SIGUSR1))
+	ctx, cancel := Context(syscall.SIGUSR1)
 	defer cancel()
 
 	p, _ := os.FindProcess(os.Getpid())
@@ -66,17 +65,11 @@ func TestContextWithCustomSignal(t *testing.T) {
 	}
 }
 
-func TestContextWithNoSignals(t *testing.T) {
-	ctx, cancel := Context(WithSignals())
-	defer cancel()
-
-	if ctx.Err() != nil {
-		t.Fatal("context should not be cancelled yet")
-	}
-
-	cancel()
-	if ctx.Err() != context.Canceled {
-		t.Fatal("context should be cancelled after cancel()")
+func TestRunWithNoSignals(t *testing.T) {
+	// WithSignals() on Run disables signal handling
+	cfg := applyOptions([]RunOption{WithSignals()})
+	if len(cfg.signals) != 0 {
+		t.Fatalf("expected 0 signals, got %d", len(cfg.signals))
 	}
 }
 

--- a/cobras_test.go
+++ b/cobras_test.go
@@ -1,75 +1,156 @@
 package cobras
 
 import (
+	"context"
+	"errors"
 	"os"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
-func TestDefaultConfig(t *testing.T) {
-	cfg := defaultConfig()
-	if len(cfg.signals) != 1 {
-		t.Fatalf("expected 1 default signal, got %d", len(cfg.signals))
+type fakeOpts struct {
+	completeCalled bool
+	validateCalled bool
+	runCalled      bool
+	completeErr    error
+	validateErr    error
+	runErr         error
+}
+
+func (f *fakeOpts) Complete(cmd *cobra.Command, args []string) error {
+	f.completeCalled = true
+	return f.completeErr
+}
+
+func (f *fakeOpts) Validate() error {
+	f.validateCalled = true
+	return f.validateErr
+}
+
+func (f *fakeOpts) Run(ctx context.Context) error {
+	f.runCalled = true
+	return f.runErr
+}
+
+func TestRun(t *testing.T) {
+	opts := &fakeOpts{}
+	cmd := &cobra.Command{
+		Run: Run(opts),
 	}
-	if cfg.signals[0] != os.Interrupt {
-		t.Fatalf("expected os.Interrupt, got %v", cfg.signals[0])
+
+	if err := ExecuteE(cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !opts.completeCalled {
+		t.Fatal("expected Complete to be called")
+	}
+	if !opts.validateCalled {
+		t.Fatal("expected Validate to be called")
+	}
+	if !opts.runCalled {
+		t.Fatal("expected Run to be called")
 	}
 }
 
-func TestWithSignals(t *testing.T) {
-	cfg := applyOptions([]RunOption{WithSignals(syscall.SIGTERM, syscall.SIGHUP)})
-	if len(cfg.signals) != 2 {
-		t.Fatalf("expected 2 signals, got %d", len(cfg.signals))
+func TestRunE(t *testing.T) {
+	opts := &fakeOpts{}
+	cmd := &cobra.Command{
+		RunE: RunE(opts),
 	}
-	if cfg.signals[0] != syscall.SIGTERM || cfg.signals[1] != syscall.SIGHUP {
-		t.Fatalf("unexpected signals: %v", cfg.signals)
+
+	if err := ExecuteE(cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-}
 
-func TestWithSignalsEmpty(t *testing.T) {
-	cfg := applyOptions([]RunOption{WithSignals()})
-	if len(cfg.signals) != 0 {
-		t.Fatalf("expected 0 signals, got %d", len(cfg.signals))
+	if !opts.completeCalled {
+		t.Fatal("expected Complete to be called")
 	}
-}
-
-func TestContextDefaultCancelsOnInterrupt(t *testing.T) {
-	ctx, cancel := Context()
-	defer cancel()
-
-	// Send ourselves SIGINT
-	p, _ := os.FindProcess(os.Getpid())
-	p.Signal(os.Interrupt)
-
-	select {
-	case <-ctx.Done():
-		// expected
-	case <-time.After(time.Second):
-		t.Fatal("context was not cancelled after SIGINT")
+	if !opts.validateCalled {
+		t.Fatal("expected Validate to be called")
+	}
+	if !opts.runCalled {
+		t.Fatal("expected Run to be called")
 	}
 }
 
-func TestContextWithCustomSignal(t *testing.T) {
-	ctx, cancel := Context(syscall.SIGUSR1)
-	defer cancel()
+func TestRunECompleteError(t *testing.T) {
+	opts := &fakeOpts{completeErr: errors.New("complete failed")}
+	cmd := &cobra.Command{
+		RunE:          RunE(opts),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
 
-	p, _ := os.FindProcess(os.Getpid())
-	p.Signal(syscall.SIGUSR1)
-
-	select {
-	case <-ctx.Done():
-		// expected
-	case <-time.After(time.Second):
-		t.Fatal("context was not cancelled after SIGUSR1")
+	if err := ExecuteE(cmd); err == nil {
+		t.Fatal("expected error from Complete")
+	}
+	if opts.validateCalled {
+		t.Fatal("Validate should not be called when Complete fails")
+	}
+	if opts.runCalled {
+		t.Fatal("Run should not be called when Complete fails")
 	}
 }
 
-func TestRunWithNoSignals(t *testing.T) {
-	// WithSignals() on Run disables signal handling
-	cfg := applyOptions([]RunOption{WithSignals()})
-	if len(cfg.signals) != 0 {
-		t.Fatalf("expected 0 signals, got %d", len(cfg.signals))
+func TestRunEValidateError(t *testing.T) {
+	opts := &fakeOpts{validateErr: errors.New("validate failed")}
+	cmd := &cobra.Command{
+		RunE:          RunE(opts),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	if err := ExecuteE(cmd); err == nil {
+		t.Fatal("expected error from Validate")
+	}
+	if opts.runCalled {
+		t.Fatal("Run should not be called when Validate fails")
+	}
+}
+
+func TestRunERunError(t *testing.T) {
+	opts := &fakeOpts{runErr: errors.New("run failed")}
+	cmd := &cobra.Command{
+		RunE:          RunE(opts),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	err := ExecuteE(cmd)
+	if err == nil || err.Error() != "run failed" {
+		t.Fatalf("expected 'run failed', got %v", err)
+	}
+}
+
+func TestExecuteWithCustomSignal(t *testing.T) {
+	var ctxErr error
+	cmd := &cobra.Command{
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, _ := os.FindProcess(os.Getpid())
+			p.Signal(syscall.SIGUSR1)
+
+			select {
+			case <-cmd.Context().Done():
+				ctxErr = cmd.Context().Err()
+			case <-time.After(time.Second):
+				t.Fatal("context was not cancelled after SIGUSR1")
+			}
+			return nil
+		},
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	if err := ExecuteE(cmd, WithSignals(syscall.SIGUSR1)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ctxErr == nil {
+		t.Fatal("expected context to be cancelled")
 	}
 }
 

--- a/cobras_test.go
+++ b/cobras_test.go
@@ -1,0 +1,87 @@
+package cobras
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := defaultConfig()
+	if len(cfg.signals) != 1 {
+		t.Fatalf("expected 1 default signal, got %d", len(cfg.signals))
+	}
+	if cfg.signals[0] != os.Interrupt {
+		t.Fatalf("expected os.Interrupt, got %v", cfg.signals[0])
+	}
+}
+
+func TestWithSignals(t *testing.T) {
+	cfg := applyOptions([]RunOption{WithSignals(syscall.SIGTERM, syscall.SIGHUP)})
+	if len(cfg.signals) != 2 {
+		t.Fatalf("expected 2 signals, got %d", len(cfg.signals))
+	}
+	if cfg.signals[0] != syscall.SIGTERM || cfg.signals[1] != syscall.SIGHUP {
+		t.Fatalf("unexpected signals: %v", cfg.signals)
+	}
+}
+
+func TestWithSignalsEmpty(t *testing.T) {
+	cfg := applyOptions([]RunOption{WithSignals()})
+	if len(cfg.signals) != 0 {
+		t.Fatalf("expected 0 signals, got %d", len(cfg.signals))
+	}
+}
+
+func TestContextDefaultCancelsOnInterrupt(t *testing.T) {
+	ctx, cancel := Context()
+	defer cancel()
+
+	// Send ourselves SIGINT
+	p, _ := os.FindProcess(os.Getpid())
+	p.Signal(os.Interrupt)
+
+	select {
+	case <-ctx.Done():
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("context was not cancelled after SIGINT")
+	}
+}
+
+func TestContextWithCustomSignal(t *testing.T) {
+	ctx, cancel := Context(WithSignals(syscall.SIGUSR1))
+	defer cancel()
+
+	p, _ := os.FindProcess(os.Getpid())
+	p.Signal(syscall.SIGUSR1)
+
+	select {
+	case <-ctx.Done():
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("context was not cancelled after SIGUSR1")
+	}
+}
+
+func TestContextWithNoSignals(t *testing.T) {
+	ctx, cancel := Context(WithSignals())
+	defer cancel()
+
+	if ctx.Err() != nil {
+		t.Fatal("context should not be cancelled yet")
+	}
+
+	cancel()
+	if ctx.Err() != context.Canceled {
+		t.Fatal("context should be cancelled after cancel()")
+	}
+}
+
+func TestContextCancelStopsListening(t *testing.T) {
+	_, cancel := Context()
+	cancel()
+	// Should not panic or leak; verifies cleanup runs cleanly.
+}


### PR DESCRIPTION
## Summary
- Add `ExecuteOption` type (renamed from `RunOption`) with `WithSignals(...)` to configure which OS signals trigger context cancellation on `Execute`/`ExecuteE`
- Add `RunE`: like `Run` but returns errors instead of calling `os.Exit`
- Add `ExecuteE`: like `Execute` but returns errors instead of calling `os.Exit`
- Add doc comments to all exported symbols (`Options`, `Run`, `RunE`, `Context`, `Execute`, `ExecuteE`, `ExecuteOption`, `WithSignals`)
- Signal handling removed from `Run`/`RunE` — context is set up by `Execute`/`ExecuteE`
- Fix bug in `Context` where signal goroutine called named return `cancel()` instead of `origCancel()`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All 7 tests pass (`go test -v ./...`)
- [x] Tests cover: Run, RunE (happy + error for each phase), ExecuteE with custom signal, context cleanup